### PR TITLE
Update unmountComponentAtNode calls.

### DIFF
--- a/dist/frame.js
+++ b/dist/frame.js
@@ -79,6 +79,6 @@ module.exports = React.createClass({
     ReactDOM.render(nextProps.children, frame.contentDocument.body);
   },
   componentWillUnmount: function componentWillUnmount() {
-    React.unmountComponentAtNode(ReactDOM.findDOMNode(this).contentDocument.body);
+    ReactDOM.unmountComponentAtNode(ReactDOM.findDOMNode(this).contentDocument.body);
   }
 });

--- a/lib/frame.js
+++ b/lib/frame.js
@@ -79,6 +79,6 @@ module.exports = React.createClass({
   },
 
   componentWillUnmount() {
-    React.unmountComponentAtNode(ReactDOM.findDOMNode(this).contentDocument.body);
+    ReactDOM.unmountComponentAtNode(ReactDOM.findDOMNode(this).contentDocument.body);
   }
 });


### PR DESCRIPTION
This is deprecated on the React object and now exists in ReactDOM.